### PR TITLE
Fix for a breaking change in webpack2 for loaders

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@
 import {Browser, Events, Flash, Mediator, Styler, UICorePlugin, template} from 'clappr'
 
 import flashHTML from '../public/flash.html'
-import flashStyle from '!raw!sass!../public/flash.scss'
+import flashStyle from '!raw-loader!sass-loader!../public/flash.scss'
 
 export default class RTMP extends Flash {
     get name() { return 'rtmp' }


### PR DESCRIPTION
Module not found: Error: Can't resolve 'raw' in '/home/.../node_modules/clappr-rtmp/src'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'raw-loader' instead of 'raw',
                 see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed